### PR TITLE
fix: update ts-node-dev to v1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "tsc": "tsc",
-    "dev": "ts-node-dev --respawn --transpileOnly ./app/server.ts",
+    "dev": "ts-node-dev --respawn --transpile-only ./app/server.ts",
     "prod": "tsc && node ./build/server.js"
   },
   "author": "",
@@ -21,7 +21,7 @@
     "@types/faker": "4.1.4",
     "@types/lodash": "4.14.119",
     "@types/node": "12.12.2",
-    "ts-node-dev": "1.0.0-pre.44",
+    "ts-node-dev": "1.1.1",
     "tslint": "6.1.0",
     "typescript": "3.8.3"
   },


### PR DESCRIPTION
The current version of `ts-node-dev` fails on node v14.15.4:

```
TypeError [ERR_FEATURE_UNAVAILABLE_ON_PLATFORM]: The feature watch recursively is unavailable on the current platform, which is being used to run Node.js
    at Object.watch (fs.js:1521:11)
    at add (/home/tsonev/rpsapi/node_modules/filewatcher/index.js:74:34)
    at /home/tsonev/rpsapi/node_modules/filewatcher/index.js:93:5
    at FSReqCallback.oncomplete (fs.js:184:5)
```